### PR TITLE
円グラフ上下表示領域足りない場合一行にする

### DIFF
--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -499,7 +499,8 @@ open class PieChartRenderer: NSObject, DataRenderer
                                                       .foregroundColor: entryLabelColor ?? valueTextColor],
                                          isUpperSemicircle:isUpperSemicircle,
                                          drawWithWidth: true,
-                                         maxWidth: center.x * 2)
+                                         maxWidth: center.x * 2,
+                                         maxHeight: center.y * 2)
                         
                         if j < data.entryCount && pe?.label != nil
                         {
@@ -536,7 +537,8 @@ open class PieChartRenderer: NSObject, DataRenderer
                                                       .foregroundColor: entryLabelColor ?? valueTextColor],
                                          isUpperSemicircle:isUpperSemicircle,
                                          drawWithWidth: true,
-                                         maxWidth: center.x * 2)
+                                         maxWidth: center.x * 2,
+                                         maxHeight: center.y * 2)
                     }
                 }
 
@@ -555,7 +557,8 @@ open class PieChartRenderer: NSObject, DataRenderer
                                          attributes: [.font: entryLabelFont ?? valueFont, .foregroundColor: entryLabelColor ?? valueTextColor],
                                          isUpperSemicircle:isUpperSemicircle,
                                          drawWithWidth: true,
-                                         maxWidth: center.x * 2)
+                                         maxWidth: center.x * 2,
+                                         maxHeight: center.y * 2)
                         
                         if j < data.entryCount && pe?.label != nil
                         {
@@ -588,7 +591,8 @@ open class PieChartRenderer: NSObject, DataRenderer
                                          attributes: [.font: entryLabelFont ?? valueFont, .foregroundColor: entryLabelColor ?? valueTextColor],
                                          isUpperSemicircle:isUpperSemicircle,
                                          drawWithWidth: true,
-                                         maxWidth: center.x * 2)
+                                         maxWidth: center.x * 2,
+                                         maxHeight: center.y * 2)
                     }
                 }
 

--- a/Source/Charts/Utils/ChartUtils.swift
+++ b/Source/Charts/Utils/ChartUtils.swift
@@ -157,7 +157,7 @@ extension CGContext
         NSUIGraphicsPopContext()
     }
 
-    open func drawText(_ text: String, at point: CGPoint, align: TextAlignment, anchor: CGPoint = CGPoint(x: 0.5, y: 0.5), angleRadians: CGFloat = 0.0, attributes: [NSAttributedString.Key : Any]?, isUpperSemicircle:Bool = false, drawWithWidth:Bool = false, maxWidth:CGFloat? = nil)
+    open func drawText(_ text: String, at point: CGPoint, align: TextAlignment, anchor: CGPoint = CGPoint(x: 0.5, y: 0.5), angleRadians: CGFloat = 0.0, attributes: [NSAttributedString.Key : Any]?, isUpperSemicircle:Bool = false, drawWithWidth:Bool = false, maxWidth:CGFloat? = nil, maxHeight:CGFloat? = nil)
     {
         var mutableAttributes = attributes
         let paragraphStyle = MutableParagraphStyle()
@@ -180,7 +180,7 @@ extension CGContext
         subText = text.count > 12 ? text.prefix(11) + "…" : text
         var displayText = subText != nil ? subText! : text
         
-        let drawPoint = getDrawPoint(text: displayText, point: point, align: align, attributes: mutableAttributes, isUpperSemicircle: isUpperSemicircle, maxWidth: maxWidth)
+        var drawPoint = getDrawPoint(text: displayText, point: point, align: align, attributes: mutableAttributes, isUpperSemicircle: isUpperSemicircle, maxWidth: maxWidth)
         if drawWithWidth {
             guard let maxWidth = maxWidth else {
                 return
@@ -194,11 +194,21 @@ extension CGContext
                 height = twoLineHeight
                 width! += drawPoint.x
                 x = 0
-            }
-            else if drawPoint.x + width! > maxWidth {
+            } else if drawPoint.x + width! > maxWidth {
                 height = twoLineHeight
                 width! -= drawPoint.x + width! - maxWidth
             }
+            
+            if let maxHeight = maxHeight {
+                if drawPoint.y < 0 {
+                    drawPoint.y += font.pointSize + paragraphStyle.lineSpacing
+                    y = drawPoint.y
+                    height = font.pointSize
+                } else if drawPoint.y + (height ?? font.pointSize) > maxHeight {
+                    height = font.pointSize
+                }
+            }
+            
         }
         
         if (angleRadians == 0.0)


### PR DESCRIPTION
## issue
https://github.com/r-n-i/code-ios/pull/3425#issuecomment-952607858

## やったこと
- 円グラフ上下表示領域足りない場合一行にする

## 仕様・デザイン
https://rni.esa.io/posts/1892#改行したときにカテゴリ名の上下が収まらないケース

## テストした項目
- [x] 上がはみ出る場合一行にする
- [x] 下がはみ出る場合一行にする

## スクリーンショット

https://user-images.githubusercontent.com/44150335/139038993-098f9d3c-e4df-4151-b753-af9eb66f5280.MP4

## リリース時の注意点