### PR TITLE
カテゴリ名が英文字一個の場合落ちる不具合修正

### DIFF
--- a/ChartsDemo-iOS/Swift/DemoBaseViewController.swift
+++ b/ChartsDemo-iOS/Swift/DemoBaseViewController.swift
@@ -97,8 +97,8 @@ enum Option {
 
 class DemoBaseViewController: UIViewController, ChartViewDelegate {
     private var optionsTableView: UITableView? = nil
-    let parties = ["アクセサリー・小物", "アクセサリー・小物アクセサリー・小物", "靴", "スポーツ用品", "Party E", "Party F",
-                   "Party G", "Party H", "Party I", "Party J", "Party K", "Party L",
+    let parties = ["アクセサリー・小物", "アクセサリー小物アクセサリー小物", "靴", "スポーツ用品スポーツ用品", "Party EParty KParty K", "Party FParty K",
+                   "G", "H小物", "Party I", "Party J", "Party K", "Party L",
                    "Party M", "Party N", "Party O", "Party P", "Party Q", "Party R",
                    "Party S", "Party T", "Party U", "Party V", "Party W", "Party X",
                    "Party Y", "Party Z"]

--- a/ChartsDemo-iOS/Swift/Demos/PiePolylineChartViewController.swift
+++ b/ChartsDemo-iOS/Swift/Demos/PiePolylineChartViewController.swift
@@ -62,7 +62,7 @@ class PiePolylineChartViewController: DemoBaseViewController {
     func setDataCount(_ count: Int, range: UInt32) {
         let entries = (0..<count).map { (i) -> PieChartDataEntry in
             // IMPORTANT: In a PieChart, no values (Entry) should have the same xIndex (even if from different DataSets), since no values can be drawn above each other.
-            return PieChartDataEntry(value: Double(arc4random_uniform(range) + range / 5),
+            return PieChartDataEntry(value: 50,
                                      label: parties[i % parties.count])
         }
         
@@ -74,10 +74,10 @@ class PiePolylineChartViewController: DemoBaseViewController {
         
         set.colors = colors
         set.valueColors = colors
-        set.valueLineColor = .clear
+//        set.valueLineColor = .clear
         
         set.valueLinePart1OffsetPercentage = 0.8
-        set.valueLinePart1Length = 0.38
+        set.valueLinePart1Length = 0.34
         set.valueLinePart2Length = 0
         //set.xValuePosition = .outsideSlice
         set.yValuePosition = .outsideSlice

--- a/Source/Charts/Utils/ChartUtils.swift
+++ b/Source/Charts/Utils/ChartUtils.swift
@@ -215,9 +215,12 @@ extension CGContext
         {
             NSUIGraphicsPushContext(self)
             
-            if let width = width, let height = height, let x = x, let y = y {
+            if var width = width, let height = height, let x = x, let y = y {
+                if width < font.pointSize {
+                    width = font.pointSize
+                }
                 let maxDisplayTextCount:Int = Int(width / font.pointSize) * Int(height / font.pointSize)
-                if displayText.count > maxDisplayTextCount {
+                if displayText.count > 6 && displayText.count > maxDisplayTextCount {
                     displayText = text.prefix(maxDisplayTextCount - 1) + "…"
                 }
                 (displayText as NSString).draw(in: CGRect.init(x: x, y: y, width: width, height: height), withAttributes: mutableAttributes)


### PR DESCRIPTION
## issue

## やったこと
カテゴリ名が英文字一個の場合落ちる不具合修正

## 仕様・デザイン
https://r-n-i.slack.com/archives/C016C62LRU7/p1636104416025100

## テストした項目
- [x] カテゴリ名が英文字一個の場合表示する

## スクリーンショット

size | before | after
 ---- | ---- | ----
5.7インチ |  | <img src="https://user-images.githubusercontent.com/44150335/140496913-b9f5d66d-e3d6-4b9e-9eda-cde15e6cc4b7.PNG" width="320" /> 

## リリース時の注意点